### PR TITLE
Support specifying working directory as an option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,15 +25,18 @@ major version of mocha. Please note that mocha is no longer a peer dependency
 as peer dependencies are being deprecated. See [npm/npm#6565][npm] for more
 info.
 
-There are two special options: `bin` and `env`. You can set `bin` to be a path
-to a `mocha` executable to use instead of the one this plugin looks for by
-default. This is useful if you want to use a fork of `mocha` which goes by a
-different name or a different executable altogether.
+The plugin accepts these special options:
 
-You can pass an object as the `env` option to set the environment variables
-that the child process will have access to (key-value pairs, see
-[child_process::spawn][spawn]). These variables are merged with your current
-environment variables and sent to the mocha executable.
+* `bin`: a path to a `mocha` executable to use instead of the one this plugin 
+looks for by default. This is useful if you want to use a fork of `mocha` 
+which goes by a different name or a different executable altogether.
+* `env`: the environment variables that the child process will have access to
+(key-value pairs, see [child_process::spawn][spawn]). These variables are 
+merged with your current environment variables and sent to the mocha 
+executable.
+* `cwd`: the working directory for the child process. This can be used to put
+files that the test creates or reads from the working directory in a specific 
+directory, instead of the directory where you are running gulp from. 
 
 All other options are properly prefixed with either `-` or `--` and passed to
 the `mocha` executable. Any arguments which do not take a value (e.g., `c`,

--- a/lib/index.js
+++ b/lib/index.js
@@ -24,8 +24,8 @@ module.exports = function (ops, coverage) {
   // Using istanbul? Use _mocha, otherwise use mocha in order to support full node options (e.g., --debug-brk)
   var bin = ops.bin || join(require.resolve('mocha'), '..', 'bin', ist ? '_mocha' : 'mocha');
   var env = _.extend(_.clone(process.env), ops.env || {});
-
-  ops = _.omit(ops, ['bin', 'env', 'istanbul']);
+  var cwd = ops.cwd;
+  ops = _.omit(ops, ['bin', 'env', 'istanbul', 'cwd']);
 
   // Create stream
   var stream = through(function (file) {
@@ -45,7 +45,7 @@ module.exports = function (ops, coverage) {
       args.unshift('cover');
     }
     // Execute Mocha, stdin and stdout are inherited
-    this._child = proc.fork(bin, args.concat(this._files), {env:env});
+    this._child = proc.fork(bin, args.concat(this._files), {env:env, cwd: cwd});
     // If there's an error running the process. See http://nodejs.org/api/child_process.html#child_process_event_error
     this._child.on('error', function (e) {
       that.emit('error', new PluginError('gulp-spawn-mocha', e));


### PR DESCRIPTION
if tests need to create temporary output files of any kind relative to the working directory, it's useful to change the working directory to constrain those output files to a specific location.