### PR TITLE
Reports output

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,40 @@ The `coveralls` module requires no additional configuration to publish to
 Coveralls as long as both Travis and Coveralls are configured for the same
 *public* repository. See [`node-coveralls`][ncov] for more details.
 
+#### Output reports to a specify file
+
+You can pass `outstream` option to output reports to a specify file.`outstream` could be a file path or a file stream.
+Note,if you are useing `istanbul`,your reports content may contain `istanbul`'s result.
+
+Use file path:
+```js
+gulp.task('test', function () {
+  return gulp.src(['test/*.test.js'], {read: false})
+    .pipe(mocha({
+      debugBrk: DEBUG,
+      r: 'test/setup.js',
+      R: CI ? 'spec' : 'nyan',
+      istanbul: !DEBUG,
+      outstream: 'result.log'
+    }));
+});
+```
+
+Use file stream:
+```js
+gulp.task('test', function () {
+  return gulp.src(['test/*.test.js'], {read: false})
+    .pipe(mocha({
+      debugBrk: DEBUG,
+      r: 'test/setup.js',
+      R: CI ? 'spec' : 'nyan',
+      istanbul: !DEBUG,
+      outstream: fs.createWriteStream('result.log', {flags: 'w'})
+    }));
+});
+```
+
+
 ## This or `gulp-mocha`?
 
 The original `gulp-mocha` is fine in most circumstances. If you need your

--- a/README.md
+++ b/README.md
@@ -160,7 +160,29 @@ This will launch a process equivilant to:
 istanbul cover --dir path/to/custom/output/directory -- _mocha
 ```
 
-This will output do a directory called `path/to/custom/output/directory`.
+This will output to a directory called `path/to/custom/output/directory`.
+
+Istanbul, like `mocha`, supports a custom `bin` option so you can use a custom
+fork of Istanbul:
+
+```javascript
+gulp.task('test', function() {
+  return gulp
+    .src(['test/*.test.js'])
+    .pipe(mocha({
+      istanbul: {
+        dir: 'path/to/custom/output/directory',
+        bin: require.resolve('isparta') + '/bin/isparta'
+      }
+    }));
+});
+```
+
+This will launch a process equivilant to:
+
+```
+./node_modules/isparta/bin/isparta cover --dir path/to/custom/output/directory -- _mocha
+```
 
 #### Publishing Coverage Reports
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -38,12 +38,11 @@ module.exports = function (ops, coverage) {
     // Using istanbul?
     if (ist) {
       args.unshift('--', bin);
-      // If the value for istanbul is literally true, just keep the arguments array. Otherwise, parse istanbul options.
-      args = ist === true ? args : parseArgs(ist).concat(args);
-      args.unshift('cover');
       // The non-standard location of istanbul's bin makes me a wee bit nervous. Find it by inspecting package.json.
-      var istPkg = require('istanbul/package.json');
-      bin = join(require.resolve('istanbul'), '..', istPkg.bin.istanbul);
+      bin = ist.bin || join(require.resolve('istanbul'), '..', require('istanbul/package.json').bin.istanbul);
+      // If the value for istanbul is literally true, just keep the arguments array. Otherwise, parse istanbul options.
+      args = ist === true ? args : parseArgs(_.omit(ist, ['bin'])).concat(args);
+      args.unshift('cover');
     }
     // Execute Mocha, stdin and stdout are inherited
     this._child = proc.fork(bin, args.concat(this._files), {env:env});

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -88,5 +88,11 @@ describe('gulp-spawn-mocha tests', function () {
       stream.end();
       proc.fork.should.be.calledWith(bin, ['cover', '--verbose', '--print', 'detail', '--', mbin]);
     });
+
+    it('can use a custom binary', function () {
+      var stream = this.stream = mocha({istanbul: {bin: 'isparta'}});
+      stream.end();
+      proc.fork.should.be.calledWith('isparta', ['cover', '--', mbin]);
+    });
   });
 });


### PR DESCRIPTION
support an `outstream` option to outpot the result to a file.
```js
gulp.task('test', function () {
  return gulp.src(['test/*.test.js'], {read: false})
    .pipe(mocha({
      debugBrk: DEBUG,
      r: 'test/setup.js',
      R: CI ? 'spec' : 'nyan',
      istanbul: !DEBUG,
      outstream: 'result.log'
    }));
});
```