### PR TITLE
support an `outstream` option to outpot the result to a file.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 coverage
 node_modules
+.idea
+result.log

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,6 @@
 // Module Requirements
 var _ = require('lodash'),
+    fs = require('fs'),
     through = require('through'),
     proc = require('child_process'),
     join = require('path').join,
@@ -21,6 +22,7 @@ module.exports = function (ops, coverage) {
   ops = ops || {};
   // Setup
   var ist = ops.istanbul;
+  var outstream = ops.outstream;
   // Using istanbul? Use _mocha, otherwise use mocha in order to support full node options (e.g., --debug-brk)
   var bin = ops.bin || join(require.resolve('mocha'), '..', 'bin', ist ? '_mocha' : 'mocha');
   var env = _.extend(_.clone(process.env), ops.env || {});
@@ -33,6 +35,7 @@ module.exports = function (ops, coverage) {
   }, function () {
     // Save refernce to this (bindless context cheat)
     var that = this;
+
     // Parse arguments
     var args = parseArgs(ops);
     // Using istanbul?
@@ -45,7 +48,7 @@ module.exports = function (ops, coverage) {
       args.unshift('cover');
     }
     // Execute Mocha, stdin and stdout are inherited
-    this._child = proc.fork(bin, args.concat(this._files), {env:env, cwd: cwd});
+    this._child = proc.fork(bin, args.concat(this._files), {env: env, silent: !!outstream});
     // If there's an error running the process. See http://nodejs.org/api/child_process.html#child_process_event_error
     this._child.on('error', function (e) {
       that.emit('error', new PluginError('gulp-spawn-mocha', e));
@@ -58,6 +61,12 @@ module.exports = function (ops, coverage) {
       }
       that.emit('end');
     });
+    //outout stream to a file
+    if (outstream) {
+      var s = /string/i.test(typeof outstream) ? fs.createWriteStream(outstream, {flags: 'w'}) : outstream;
+      that._child.stdout.pipe(s);
+      that._child.stderr.pipe(s);
+    }
   });
 
   // Attach files array to stream

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -3,7 +3,8 @@ describe('gulp-spawn-mocha tests', function () {
       through = require('through'),
       proc = require('child_process'),
       join = require('path').join,
-      PluginError = require('gulp-util').PluginError;
+      PluginError = require('gulp-util').PluginError,
+      fs = require('fs');
 
   beforeEach(function () {
     sinon.stub(proc, 'fork');
@@ -70,6 +71,12 @@ describe('gulp-spawn-mocha tests', function () {
       stream.end();
       this.childOn.should.be.calledTwice;
       stream.emit.should.be.calledWith('error', sinon.match.instanceOf(PluginError));
+    });
+
+    it('should output a result.log file', function () {
+      var stream = this.stream = mocha({outstream: 'result.log'});
+      stream.end();
+      return fs.existsSync('result.log');
     });
   });
 


### PR DESCRIPTION
support an `outstream` option to outpot the result to a file.
```js
gulp.task('test', function () {
  return gulp.src(['test/*.test.js'], {read: false})
    .pipe(mocha({
      debugBrk: DEBUG,
      r: 'test/setup.js',
      R: CI ? 'spec' : 'nyan',
      istanbul: !DEBUG,
      outstream: 'result.log'
    }));
});
```